### PR TITLE
🐛  Make sure txParser uses BN for mining transaction fees calculation

### DIFF
--- a/cc/txParser.js
+++ b/cc/txParser.js
@@ -100,7 +100,7 @@ const parseTransactionData = (tx) => {
     if (tx.ins.length > 1 && tx.ins[0].tx) {
       // skip C-index addresses since those are CC transactions
       sumIns = tx.ins.reduce((a, b) => isCindexAddress(b.tx?.address) ? a : a.add(b.tx?.value), new BN());
-      fees = sumIns - sumOuts
+      fees = sumIns.sub(sumOuts)
     } else {
       fees = FIXED_FEE;
     }


### PR DESCRIPTION
This was causing some wallets with mining inputs to crash as the txValue would sometimes exceed `MAX_SAFE_INTEGER` and not use BigNumber.