### PR TITLE
Fixed transaction value parsing bug

### DIFF
--- a/cc/txParser.js
+++ b/cc/txParser.js
@@ -121,6 +121,17 @@ const parseTransactionData = (tx, requestedAddress) => {
       }
     })
 
+    // If I m not the one receiving change, I am prolly the receiver
+    if ((changeReceivingAddress !== requestedAddress) && recipients.indexOf(requestedAddress) !== -1) {
+      sumOuts = new BN(tx.outs.find(a => a.address === requestedAddress).value);
+      return {
+        fees,
+        value: sumOuts,
+        senders,
+        recipients
+      }
+    }
+    
     // calculate change
     if (changeReceivingAddress) {
       const txToAddress = tx.outs.find(s => s.address === changeReceivingAddress)


### PR DESCRIPTION
Extended parsing by rulling out transactions which have the requested address as receiver

Saw the issue with this transaction: https://explorer.tokel.io/tx/035a8292be7e140810f34f1dbb3cd642fb115a43e19dccbb7e3a8ca3a93f9296